### PR TITLE
Move eslint-plugin-ava to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,10 @@
   "files": [
     "index.js"
   ],
-  "dependencies": {
-    "eslint-plugin-ava": "^4.2.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "browserify": "^14.0.0",
+     "eslint-plugin-ava": "^4.2.0",
     "esmangle": "^1.0.0",
     "nyc": "^11.0.0",
     "remark-cli": "^3.0.0",


### PR DESCRIPTION
I noticed that eslint-plugin-ava has started being included in debugger.html's node_modules because of this recent change: https://github.com/syntax-tree/mdast-util-to-string/commit/9e3a60567314755409f41cc3d4fd7d0d562e7d56

Is it intentional? If so, what's the rationale?